### PR TITLE
Fixed issue

### DIFF
--- a/ExpandingStackCells/Data/SimpleItemStore.swift
+++ b/ExpandingStackCells/Data/SimpleItemStore.swift
@@ -14,6 +14,16 @@ struct SimpleItemStore {
             SimpleItem(title: "A really long item title for testing self-sizing mechanism", detail: "A really long detail title to test self-sizing mechanism"),
             SimpleItem(title: "Item 1", detail: "Detail 1"),
             SimpleItem(title: "Item 2", detail: "Detail 2"),
+            
+            SimpleItem(title: "A really long item title for testing self-sizing mechanism", detail: "A really long detail title to test self-sizing mechanism"),
+            SimpleItem(title: "Item 1", detail: "Detail 1"),
+            SimpleItem(title: "Item 2", detail: "Detail 2"),
+            SimpleItem(title: "A really long item title for testing self-sizing mechanism", detail: "A really long detail title to test self-sizing mechanism"),
+            SimpleItem(title: "Item 1", detail: "Detail 1"),
+            SimpleItem(title: "Item 2", detail: "Detail 2"),
+            SimpleItem(title: "A really long item title for testing self-sizing mechanism", detail: "A really long detail title to test self-sizing mechanism"),
+            SimpleItem(title: "Item 1", detail: "Detail 1"),
+            SimpleItem(title: "Item 2", detail: "Detail 2"),
         ]
     }
 }

--- a/ExpandingStackCells/View controllers/MainViewController.swift
+++ b/ExpandingStackCells/View controllers/MainViewController.swift
@@ -44,9 +44,10 @@ class MainViewController: UITableViewController {
     override func tableView(tableView: UITableView, willSelectRowAtIndexPath indexPath: NSIndexPath) -> NSIndexPath? {
         
         if let selectedIndex = tableView.indexPathForSelectedRow where selectedIndex == indexPath {
-            
+            let cell = tableView.cellForRowAtIndexPath(selectedIndex) as! ExpandingCell
             tableView.beginUpdates()
             tableView.deselectRowAtIndexPath(indexPath, animated: true)
+            cell.changeCellStatus(false)
             tableView.endUpdates()
             
             return nil
@@ -56,6 +57,8 @@ class MainViewController: UITableViewController {
     }
     
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
+        let cell = tableView.cellForRowAtIndexPath(indexPath) as! ExpandingCell
+        cell.changeCellStatus(true)
         tableView.beginUpdates()
         tableView.endUpdates()
     }

--- a/ExpandingStackCells/Views/ExpandingCell.swift
+++ b/ExpandingStackCells/Views/ExpandingCell.swift
@@ -31,18 +31,30 @@ class ExpandingCell: UITableViewCell {
         stackView.arrangedSubviews.last?.hidden = true
     }
     
-    override func setSelected(selected: Bool, animated: Bool) {
-        
-        super.setSelected(selected, animated: animated)
-        
+//    override func setSelected(selected: Bool, animated: Bool) {
+//        
+//        super.setSelected(selected, animated: animated)
+//        
+//        UIView.animateWithDuration(0.5,
+//            delay: 0,
+//            usingSpringWithDamping: 1,
+//            initialSpringVelocity: 1,
+//            options: UIViewAnimationOptions.CurveEaseIn,
+//            animations: { () -> Void in
+//                self.stackView.arrangedSubviews.last?.hidden = !selected
+//            },
+//            completion: nil)
+//    }
+
+    func changeCellStatus(selected: Bool){
         UIView.animateWithDuration(0.5,
-            delay: 0,
-            usingSpringWithDamping: 1,
-            initialSpringVelocity: 1,
-            options: UIViewAnimationOptions.CurveEaseIn,
-            animations: { () -> Void in
-                stackView.arrangedSubviews.last?.hidden = !selected
+                                   delay: 0,
+                                   usingSpringWithDamping: 1,
+                                   initialSpringVelocity: 1,
+                                   options: UIViewAnimationOptions.CurveEaseIn,
+                                   animations: { () -> Void in
+                                    self.stackView.arrangedSubviews.last?.hidden = !selected
             },
-            completion: nil)
+                                   completion: nil)
     }
 }


### PR DESCRIPTION
Fixed issue caused by cell reuse, now if you have a long table, it won't be not expandable. But still have some issue here, it's cause by cell reuse, if you open one cell, and scroll, you may see other cell opened also. 

May don't use cell reuse can solve this problem.
